### PR TITLE
full.cljs.async - go-retry - should-retry-fn

### DIFF
--- a/full.cljs.async/test/full/cljs/test_async.cljs
+++ b/full.cljs.async/test/full/cljs/test_async.cljs
@@ -42,3 +42,25 @@
                 (set))
            #{2 3}))
     (done)))
+
+(deftest ^:async go-retry
+  (go
+    (is (= (let [eval-counter- (atom 0)]
+             (<? (go-retry
+                    {:should-retry-fn (fn [res] (= 0 res))
+                     :retries 3}
+                    (swap! eval-counter- inc)
+                    0))
+             @eval-counter-)
+           ; should be 4 (first attempt + 3 retries)
+           4))
+    (is (= (let [eval-counter- (atom 0)]
+             (<? (go-retry
+                   {:should-retry-fn (fn [res] (= 0 res))
+                    :retries 3}
+                   (swap! eval-counter- inc)
+                   1))
+             @eval-counter-)
+           ; should be 1 (no retries)
+           1))
+    (done)))

--- a/full.cljs.async/test/full/cljs/test_async.cljs
+++ b/full.cljs.async/test/full/cljs/test_async.cljs
@@ -1,7 +1,7 @@
 (ns full.cljs.test-async
   (:require-macros [cljs.core.async.macros :refer [go]])
   (:require [cemerick.cljs.test :as t :refer-macros [deftest is done]]
-            [full.cljs.async :refer [pmap>> ] :refer-macros [go-try <? <<? <?*]]
+            [full.cljs.async :refer [pmap>> ] :refer-macros [go-try go-retry <? <<? <?*]]
             [cljs.core.async :refer [chan take! <! >! close!]]))
 
 


### PR DESCRIPTION
depdrecated error-fn and add should-retry-fn (which is invoked every team after block evaluates)

@mattsfrey 
